### PR TITLE
Added "Comparison of speed between NumPy arrays and Python lists" section

### DIFF
--- a/Numpy/Numpy_Notebook.ipynb
+++ b/Numpy/Numpy_Notebook.ipynb
@@ -1,45 +1,54 @@
 {
   "nbformat": 4,
-  "nbformat_minor": 0,
+  "nbformat_minor": 2,
   "metadata": {
     "colab": {
-      "name": "Numpy_Notebook.ipynb",
+      "name": "MyNumpy_Notebook.ipynb",
       "provenance": [],
       "collapsed_sections": [],
       "toc_visible": true
     },
     "kernelspec": {
       "name": "python3",
-      "display_name": "Python 3"
+      "display_name": "Python 3.9.5 64-bit"
     },
     "language_info": {
-      "name": "python"
+      "name": "python",
+      "version": "3.9.5",
+      "mimetype": "text/x-python",
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "pygments_lexer": "ipython3",
+      "nbconvert_exporter": "python",
+      "file_extension": ".py"
+    },
+    "interpreter": {
+      "hash": "5298639a097483ce8efb1de2d7abe69585d0447279e541f71e89cca5f2da3b6f"
     }
   },
   "cells": [
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "jkB4c2sFR4qo"
-      },
       "source": [
         "# **Numpy**\n"
-      ]
+      ],
+      "metadata": {
+        "id": "jkB4c2sFR4qo"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "g798uXpWZQLn"
-      },
       "source": [
         "### **What is Numpy?**"
-      ]
+      ],
+      "metadata": {
+        "id": "g798uXpWZQLn"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "OS3ClcNsU9k1"
-      },
       "source": [
         "=> Numpy is a Python library or fundamental package, which is used for working with arrays. We can perform many scientific computiation on those arrays and also it is 5-100 times faster than traditional Python lists. Numpy is short for Numerical Python.\n",
         "\n",
@@ -53,39 +62,36 @@
         "\n",
         "---\n",
         "\n"
-      ]
+      ],
+      "metadata": {
+        "id": "OS3ClcNsU9k1"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "qR1UrEFYZLHW"
-      },
       "source": [
         "### **How to create basic arrays using Numpy?**"
-      ]
+      ],
+      "metadata": {
+        "id": "qR1UrEFYZLHW"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "YEUFfcTLaS-x"
-      },
       "source": [
         "=> First we need to import the Numpy library to work with it.To import Numpy module we need to write -> import numpy.\n",
         "\n",
         "But if we use \"import numpy as np\",  an alias for the namespace will be created. \n",
         "\n",
         "We can create Numpy ndarray object using array() function."
-      ]
+      ],
+      "metadata": {
+        "id": "YEUFfcTLaS-x"
+      }
     },
     {
       "cell_type": "code",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "h_W8hVsNbtp9",
-        "outputId": "7f4ad9c5-6cb6-441b-b3c5-082cd7609dec"
-      },
+      "execution_count": 53,
       "source": [
         "#Creating a Numpy array\n",
         "\n",
@@ -97,7 +103,6 @@
         "# This will print single dimensional array\n",
         "print(arr)"
       ],
-      "execution_count": 1,
       "outputs": [
         {
           "output_type": "stream",
@@ -106,33 +111,33 @@
             "[1 2 3]\n"
           ]
         }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "cE8lHIjDi99l"
-      },
-      "source": [
-        "We can pass list, tuple or array-like object in the array() method to create an ndarray."
-      ]
-    },
-    {
-      "cell_type": "code",
+      ],
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "id": "C4fhmBprjpwE",
-        "outputId": "cd9ac442-2fcd-417e-e772-e101987a13c6"
-      },
+        "id": "h_W8hVsNbtp9",
+        "outputId": "7f4ad9c5-6cb6-441b-b3c5-082cd7609dec"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "We can pass list, tuple or array-like object in the array() method to create an ndarray."
+      ],
+      "metadata": {
+        "id": "cE8lHIjDi99l"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 54,
       "source": [
         "tup=(5,6,7,8)                  # Tuple\n",
         "arr_tup=np.array(tup)          # Passing tuple in array function\n",
         "\n",
         "print(arr_tup)                 # This will print 1-D array"
       ],
-      "execution_count": 2,
       "outputs": [
         {
           "output_type": "stream",
@@ -141,26 +146,27 @@
             "[5 6 7 8]\n"
           ]
         }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "vkTaVujGlOIh"
-      },
-      "source": [
-        "We  can create array filled with zeros or ones."
-      ]
-    },
-    {
-      "cell_type": "code",
+      ],
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "id": "HZ9wOdUKlYb_",
-        "outputId": "5f588757-d971-4e4b-a611-8d6dce3d8474"
-      },
+        "id": "C4fhmBprjpwE",
+        "outputId": "cd9ac442-2fcd-417e-e772-e101987a13c6"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "We  can create array filled with zeros or ones."
+      ],
+      "metadata": {
+        "id": "vkTaVujGlOIh"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 55,
       "source": [
         "arr_0=np.zeros(4) # Using np.zeros() we can create an array of zeros. Here 4 is the number of elements (zeros)\n",
         "arr_1=np.ones(7)  # Using np.ones() we can create an array of ones. Here 7 is the number of elements (ones)\n",
@@ -168,7 +174,6 @@
         "print(arr_0)\n",
         "print(arr_1)"
       ],
-      "execution_count": 3,
       "outputs": [
         {
           "output_type": "stream",
@@ -178,26 +183,27 @@
             "[1. 1. 1. 1. 1. 1. 1.]\n"
           ]
         }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "xXgKj9jcmnnF"
-      },
-      "source": [
-        "We can create an array with a range of elements with the help of np.arange() function. We can also specify the first number, last number and step size."
-      ]
-    },
-    {
-      "cell_type": "code",
+      ],
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "id": "DUCXv08imx1i",
-        "outputId": "e3358bcf-a4f8-4e40-ead9-53c8559a1050"
-      },
+        "id": "HZ9wOdUKlYb_",
+        "outputId": "5f588757-d971-4e4b-a611-8d6dce3d8474"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "We can create an array with a range of elements with the help of np.arange() function. We can also specify the first number, last number and step size."
+      ],
+      "metadata": {
+        "id": "xXgKj9jcmnnF"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 56,
       "source": [
         "arr_1=np.arange(7)      # This will create an array starting from 0 to 6\n",
         "arr_2=np.arange(2,9,2)  # This will create an array [2,4,6,8] as the starting point=2, ending point=9, step size=2\n",
@@ -205,7 +211,6 @@
         "print(arr_1)\n",
         "print(arr_2)"
       ],
-      "execution_count": 4,
       "outputs": [
         {
           "output_type": "stream",
@@ -215,33 +220,33 @@
             "[2 4 6 8]\n"
           ]
         }
-      ]
-    },
-    {
-      "cell_type": "markdown",
+      ],
       "metadata": {
-        "id": "Y8qbSenDnI6t"
-      },
-      "source": [
-        "We can also use np.linspace() to create an array with values that are spaced linearly in a specified interval."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "ygDaGK1joN29",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "02078278-778c-446d-a213-5c54e9ad9416"
-      },
+        "id": "DUCXv08imx1i",
+        "outputId": "e3358bcf-a4f8-4e40-ead9-53c8559a1050"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "We can also use np.linspace() to create an array with values that are spaced linearly in a specified interval."
+      ],
+      "metadata": {
+        "id": "Y8qbSenDnI6t"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 57,
       "source": [
         "arr1=np.linspace(0, 10, num=5)     # This will create an array between the range 0 to 10 and there is 5 equispaced elements in this range.\n",
         "arr2=np.linspace(0, 10, num=6)     # This will create an array between the range 0 to 10 and there is 6 equispaced elements in this range.\n",
         "print(arr1)\n",
         "print(arr2)"
       ],
-      "execution_count": 5,
       "outputs": [
         {
           "output_type": "stream",
@@ -251,57 +256,58 @@
             "[ 0.  2.  4.  6.  8. 10.]\n"
           ]
         }
-      ]
+      ],
+      "metadata": {
+        "id": "ygDaGK1joN29",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "02078278-778c-446d-a213-5c54e9ad9416"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "4I-HfHASlNZF"
-      },
       "source": [
         "\n",
         "\n",
         "---\n",
         "\n",
         "\n"
-      ]
+      ],
+      "metadata": {
+        "id": "4I-HfHASlNZF"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "UE-9bNaTrzel"
-      },
       "source": [
         "### **Sorting and Concatenation of Array Elements**"
-      ]
+      ],
+      "metadata": {
+        "id": "UE-9bNaTrzel"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "ZEK7M3tSr74G"
-      },
       "source": [
         "Sorting :"
-      ]
+      ],
+      "metadata": {
+        "id": "ZEK7M3tSr74G"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "cgD_AGoassv-"
-      },
       "source": [
         "We can sort elements of numpy array using np.sort() function."
-      ]
+      ],
+      "metadata": {
+        "id": "cgD_AGoassv-"
+      }
     },
     {
       "cell_type": "code",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "dLUfN36RsQ-w",
-        "outputId": "dd3b0fd0-23f1-4921-85a0-5172568bb503"
-      },
+      "execution_count": 58,
       "source": [
         "arr=np.array([8,4,9,5,1,0,6,2,3,7])  # Unsorted array\n",
         "\n",
@@ -311,7 +317,6 @@
         "\n",
         "print(arr_sorted)                    # Printing Sorted Array"
       ],
-      "execution_count": 6,
       "outputs": [
         {
           "output_type": "stream",
@@ -321,35 +326,36 @@
             "[0 1 2 3 4 5 6 7 8 9]\n"
           ]
         }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "yJFtpo-xtnux"
-      },
-      "source": [
-        "Concatenation :"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "lzz67-8wtqdJ"
-      },
-      "source": [
-        "We can concatenate arrays using the np.concatenate() function."
-      ]
-    },
-    {
-      "cell_type": "code",
+      ],
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "id": "6JuU1i4OuNBU",
-        "outputId": "6063689c-6d7b-4d03-81af-d7d3b4d995fd"
-      },
+        "id": "dLUfN36RsQ-w",
+        "outputId": "dd3b0fd0-23f1-4921-85a0-5172568bb503"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Concatenation :"
+      ],
+      "metadata": {
+        "id": "yJFtpo-xtnux"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "We can concatenate arrays using the np.concatenate() function."
+      ],
+      "metadata": {
+        "id": "lzz67-8wtqdJ"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 59,
       "source": [
         "a = np.array([1, 2, 3, 4])\n",
         "b = np.array([5, 6, 7, 8])\n",
@@ -358,7 +364,6 @@
         "\n",
         "print(c)"
       ],
-      "execution_count": 7,
       "outputs": [
         {
           "output_type": "stream",
@@ -367,62 +372,62 @@
             "[1 2 3 4 5 6 7 8]\n"
           ]
         }
-      ]
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "6JuU1i4OuNBU",
+        "outputId": "6063689c-6d7b-4d03-81af-d7d3b4d995fd"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "gnDRQDXnr6MN"
-      },
       "source": [
         "\n",
         "\n",
         "---\n",
         "\n"
-      ]
+      ],
+      "metadata": {
+        "id": "gnDRQDXnr6MN"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "WQfGoo4rlVne"
-      },
       "source": [
         "### **Dimensions of Arrays**"
-      ]
+      ],
+      "metadata": {
+        "id": "WQfGoo4rlVne"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "2cvzAIPckUwE"
-      },
       "source": [
         "Arrays can be of different dimensions."
-      ]
+      ],
+      "metadata": {
+        "id": "2cvzAIPckUwE"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "KMdW6uXClDTX"
-      },
       "source": [
         "0-Dimensional Array:"
-      ]
+      ],
+      "metadata": {
+        "id": "KMdW6uXClDTX"
+      }
     },
     {
       "cell_type": "code",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "PwMlrcNylKNu",
-        "outputId": "71354c4a-cc32-4b5c-cc85-6497feabe275"
-      },
+      "execution_count": 60,
       "source": [
         "arr = np.array(10)\n",
         "\n",
         "print(arr)"
       ],
-      "execution_count": 8,
       "outputs": [
         {
           "output_type": "stream",
@@ -431,32 +436,32 @@
             "10\n"
           ]
         }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "YzDZmxjhljXN"
-      },
-      "source": [
-        "1-Dimensional Array:"
-      ]
-    },
-    {
-      "cell_type": "code",
+      ],
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "id": "qrM8k76klmux",
-        "outputId": "8fbd6f1b-c33d-4f49-ea7f-ad172c468ebb"
-      },
+        "id": "PwMlrcNylKNu",
+        "outputId": "71354c4a-cc32-4b5c-cc85-6497feabe275"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "1-Dimensional Array:"
+      ],
+      "metadata": {
+        "id": "YzDZmxjhljXN"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 61,
       "source": [
         "arr = np.array([1, 2, 3, 4, 5])\n",
         "\n",
         "print(arr)"
       ],
-      "execution_count": 9,
       "outputs": [
         {
           "output_type": "stream",
@@ -465,32 +470,32 @@
             "[1 2 3 4 5]\n"
           ]
         }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "eUf9UzmLls3-"
-      },
-      "source": [
-        "2-Dimensional Array:"
-      ]
-    },
-    {
-      "cell_type": "code",
+      ],
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "id": "oiZ2MxBalw3A",
-        "outputId": "3a36476b-51a1-4ba4-94c5-b646d3e0c7b0"
-      },
+        "id": "qrM8k76klmux",
+        "outputId": "8fbd6f1b-c33d-4f49-ea7f-ad172c468ebb"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "2-Dimensional Array:"
+      ],
+      "metadata": {
+        "id": "eUf9UzmLls3-"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 62,
       "source": [
         "arr = np.array([[1, 2, 3], [4, 5, 6]])    # We need to pass two lists separated by a comma to create a 2-D array\n",
         "\n",
         "print(arr)"
       ],
-      "execution_count": 10,
       "outputs": [
         {
           "output_type": "stream",
@@ -500,32 +505,32 @@
             " [4 5 6]]\n"
           ]
         }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "rLx3GcQwmKr_"
-      },
-      "source": [
-        "3-Dimensional Array:"
-      ]
-    },
-    {
-      "cell_type": "code",
+      ],
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "id": "J9iA6g7smgfI",
-        "outputId": "6c911626-21cf-414e-c122-be01b82d4757"
-      },
+        "id": "oiZ2MxBalw3A",
+        "outputId": "3a36476b-51a1-4ba4-94c5-b646d3e0c7b0"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "3-Dimensional Array:"
+      ],
+      "metadata": {
+        "id": "rLx3GcQwmKr_"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 63,
       "source": [
         "arr = np.array([[[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 5, 6]]])\n",
         "\n",
         "print(arr)"
       ],
-      "execution_count": 11,
       "outputs": [
         {
           "output_type": "stream",
@@ -538,35 +543,36 @@
             "  [4 5 6]]]\n"
           ]
         }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "G9DkBGeknkb5"
-      },
-      "source": [
-        "Higher Dimensional Array:"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "rm-fBvv-nn9q"
-      },
-      "source": [
-        "We can create higher dimensional arrays by spcifying number of dimensions using ndmin arguement."
-      ]
-    },
-    {
-      "cell_type": "code",
+      ],
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "id": "4Us_XZQZnQUI",
-        "outputId": "daa94905-26b0-4415-c75d-7919b805adf2"
-      },
+        "id": "J9iA6g7smgfI",
+        "outputId": "6c911626-21cf-414e-c122-be01b82d4757"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Higher Dimensional Array:"
+      ],
+      "metadata": {
+        "id": "G9DkBGeknkb5"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "We can create higher dimensional arrays by spcifying number of dimensions using ndmin arguement."
+      ],
+      "metadata": {
+        "id": "rm-fBvv-nn9q"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 64,
       "source": [
         "arr = np.array([1, 2, 3, 4], ndmin=5)         # Defining array dimension\n",
         "\n",
@@ -574,7 +580,6 @@
         "\n",
         "print('Number of dimensions :', arr.ndim)     # Printing array dimensions"
       ],
-      "execution_count": 12,
       "outputs": [
         {
           "output_type": "stream",
@@ -584,49 +589,50 @@
             "Number of dimensions : 5\n"
           ]
         }
-      ]
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "4Us_XZQZnQUI",
+        "outputId": "daa94905-26b0-4415-c75d-7919b805adf2"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "DqMFoRu5ux2r"
-      },
       "source": [
         "\n",
         "\n",
         "---\n",
         "\n"
-      ]
+      ],
+      "metadata": {
+        "id": "DqMFoRu5ux2r"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "_Anjv2biupV7"
-      },
       "source": [
         "### **Array Size and Shape**"
-      ]
+      ],
+      "metadata": {
+        "id": "_Anjv2biupV7"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "mfhtCdW3u0GU"
-      },
       "source": [
         "ndarray.size will tell us the total number of elements of the array. This is the product of the elements of the array’s shape.\n",
         "\n",
         "ndarray.shape will display a tuple of integers that indicate the number of elements stored along each dimension of the array."
-      ]
+      ],
+      "metadata": {
+        "id": "mfhtCdW3u0GU"
+      }
     },
     {
       "cell_type": "code",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "JEVC71tzvM8P",
-        "outputId": "96e56b7f-20d5-4e07-e8dd-2817a136cdcb"
-      },
+      "execution_count": 65,
       "source": [
         "arr=np.array([[1,2,3],[4,5,6]])\n",
         "\n",
@@ -634,7 +640,6 @@
         "print(\"Size of the array : \",arr.size)\n",
         "print(\"Shape of the array : \",arr.shape)"
       ],
-      "execution_count": 13,
       "outputs": [
         {
           "output_type": "stream",
@@ -646,47 +651,48 @@
             "Shape of the array :  (2, 3)\n"
           ]
         }
-      ]
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "JEVC71tzvM8P",
+        "outputId": "96e56b7f-20d5-4e07-e8dd-2817a136cdcb"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "qYWKiXf3zVJ8"
-      },
       "source": [
         "\n",
         "\n",
         "---\n",
         "\n"
-      ]
+      ],
+      "metadata": {
+        "id": "qYWKiXf3zVJ8"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "jyxoftvJ1vpE"
-      },
       "source": [
         "### **Array Reshape**"
-      ]
+      ],
+      "metadata": {
+        "id": "jyxoftvJ1vpE"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "PNH13mZ-125P"
-      },
       "source": [
         "Using arr.reshape() will give a new shape to an array without changing the data. We need to remember that when we are using the reshape method, the array we want to produce needs to have the same number of elements as the original array."
-      ]
+      ],
+      "metadata": {
+        "id": "PNH13mZ-125P"
+      }
     },
     {
       "cell_type": "code",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "crQG31iJ2Zj1",
-        "outputId": "61c33ba9-97de-433f-ec05-5333617adcd5"
-      },
+      "execution_count": 66,
       "source": [
         "a=np.array([1,2,3,4,5,6]) # 1-D array\n",
         "\n",
@@ -696,7 +702,6 @@
         "\n",
         "print(b)"
       ],
-      "execution_count": 14,
       "outputs": [
         {
           "output_type": "stream",
@@ -707,56 +712,57 @@
             " [4 5 6]]\n"
           ]
         }
-      ]
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "crQG31iJ2Zj1",
+        "outputId": "61c33ba9-97de-433f-ec05-5333617adcd5"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "Ln3mhttZ1st7"
-      },
       "source": [
         "\n",
         "\n",
         "---\n",
         "\n"
-      ]
+      ],
+      "metadata": {
+        "id": "Ln3mhttZ1st7"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "qqd4DUJenv8K"
-      },
       "source": [
         "### **Array Indexing**"
-      ]
+      ],
+      "metadata": {
+        "id": "qqd4DUJenv8K"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "b2948EPyn-VT"
-      },
       "source": [
         "We can access the elements of numpy array through indexes."
-      ]
+      ],
+      "metadata": {
+        "id": "b2948EPyn-VT"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "QKKV8aS3pFFP"
-      },
       "source": [
         "For 1-D array:"
-      ]
+      ],
+      "metadata": {
+        "id": "QKKV8aS3pFFP"
+      }
     },
     {
       "cell_type": "code",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "soT8EiBjn89b",
-        "outputId": "56d962ae-ff80-4376-871a-c746566d8ae0"
-      },
+      "execution_count": 67,
       "source": [
         "#Accessing 1-D array elements using indexes\n",
         "\n",
@@ -765,7 +771,6 @@
         "#Printing the array element at index 2\n",
         "print(arr[2])"
       ],
-      "execution_count": 15,
       "outputs": [
         {
           "output_type": "stream",
@@ -774,35 +779,36 @@
             "33\n"
           ]
         }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "rhn-E96hpJc3"
-      },
-      "source": [
-        "For 2-D array:"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "frIvWqiopLX0"
-      },
-      "source": [
-        "We can use comma separated integers representing the dimension and the index of the element.We can use this style of array indexing in higher order array indexing. For instance, in the case of 3-D array it will be like arr[0,1,2]."
-      ]
-    },
-    {
-      "cell_type": "code",
+      ],
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "id": "ZpYulXvRoqzd",
-        "outputId": "2ad3376d-0cad-4eb3-8a1d-3d043dbdeafa"
-      },
+        "id": "soT8EiBjn89b",
+        "outputId": "56d962ae-ff80-4376-871a-c746566d8ae0"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "For 2-D array:"
+      ],
+      "metadata": {
+        "id": "rhn-E96hpJc3"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "We can use comma separated integers representing the dimension and the index of the element.We can use this style of array indexing in higher order array indexing. For instance, in the case of 3-D array it will be like arr[0,1,2]."
+      ],
+      "metadata": {
+        "id": "frIvWqiopLX0"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 68,
       "source": [
         "# Accessing 2-D array elements using indexes\n",
         "\n",
@@ -811,7 +817,6 @@
         "print('4th element on 1st dim: ', arr[0, 3]) \n",
         "print('3th element on 2nd dim: ', arr[1, 2]) "
       ],
-      "execution_count": 16,
       "outputs": [
         {
           "output_type": "stream",
@@ -821,32 +826,32 @@
             "3th element on 2nd dim:  8\n"
           ]
         }
-      ]
-    },
-    {
-      "cell_type": "markdown",
+      ],
       "metadata": {
-        "id": "7WU5C7ofqga5"
-      },
-      "source": [
-        "Negative Indexing:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "zYw1ckNUqkIQ",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "204c0736-3236-48ec-f0c1-083752dfd74f"
-      },
+        "id": "ZpYulXvRoqzd",
+        "outputId": "2ad3376d-0cad-4eb3-8a1d-3d043dbdeafa"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Negative Indexing:"
+      ],
+      "metadata": {
+        "id": "7WU5C7ofqga5"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 69,
       "source": [
         "arr = np.array([[1,2,3,4,5], [6,7,8,9,10]])\n",
         "\n",
         "print('Last element from 2nd dim: ', arr[1, -1])      # Accessing last element of the 2nd dim"
       ],
-      "execution_count": 17,
       "outputs": [
         {
           "output_type": "stream",
@@ -855,56 +860,57 @@
             "Last element from 2nd dim:  10\n"
           ]
         }
-      ]
+      ],
+      "metadata": {
+        "id": "zYw1ckNUqkIQ",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "204c0736-3236-48ec-f0c1-083752dfd74f"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "wkf8IGWhqyur"
-      },
       "source": [
         "\n",
         "\n",
         "---\n",
         "\n"
-      ]
+      ],
+      "metadata": {
+        "id": "wkf8IGWhqyur"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "8qqOpqJCqz1Y"
-      },
       "source": [
         "### **Array Slicing**"
-      ]
+      ],
+      "metadata": {
+        "id": "8qqOpqJCqz1Y"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "ki0lakQRq3aZ"
-      },
       "source": [
         "We can also slice ndarray. It is similiar to regular slicing."
-      ]
+      ],
+      "metadata": {
+        "id": "ki0lakQRq3aZ"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "85dIhH8-rfHL"
-      },
       "source": [
         "Syntax of slicing array is-> arr [ start : end : step(optional) ]"
-      ]
+      ],
+      "metadata": {
+        "id": "85dIhH8-rfHL"
+      }
     },
     {
       "cell_type": "code",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "o-55ek10rMuh",
-        "outputId": "88a4126f-ddb0-4701-e03e-de94423497ac"
-      },
+      "execution_count": 70,
       "source": [
         "# Array slicing\n",
         "\n",
@@ -913,7 +919,6 @@
         "print(arr[1:5])                          # arr[1:5] means we are starting from index 1 and we will go upto index 4\n",
         "\n"
       ],
-      "execution_count": 18,
       "outputs": [
         {
           "output_type": "stream",
@@ -922,170 +927,170 @@
             "[2 3 4 5]\n"
           ]
         }
-      ]
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "o-55ek10rMuh",
+        "outputId": "88a4126f-ddb0-4701-e03e-de94423497ac"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "pzY8Sg9ZsfS1"
-      },
       "source": [
         "\n",
         "\n",
         "---\n",
         "\n"
-      ]
+      ],
+      "metadata": {
+        "id": "pzY8Sg9ZsfS1"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "UUHkhf4Qsgje"
-      },
       "source": [
         "### **Numpy Datatypes**"
-      ]
+      ],
+      "metadata": {
+        "id": "UUHkhf4Qsgje"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "66Ty--bysj9k"
-      },
       "source": [
         "Numpy has a lots of datatypes. The list is given below-"
-      ]
+      ],
+      "metadata": {
+        "id": "66Ty--bysj9k"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "sKGHQdDbs33e"
-      },
       "source": [
         "i -> integer"
-      ]
+      ],
+      "metadata": {
+        "id": "sKGHQdDbs33e"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "H2VV8vuRs8eX"
-      },
       "source": [
         "b -> boolean\n"
-      ]
+      ],
+      "metadata": {
+        "id": "H2VV8vuRs8eX"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "GncnaPkotrNP"
-      },
       "source": [
         "u -> unsigned integer\n"
-      ]
+      ],
+      "metadata": {
+        "id": "GncnaPkotrNP"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "VQ5qX_Wwtto2"
-      },
       "source": [
         "f -> float\n"
-      ]
+      ],
+      "metadata": {
+        "id": "VQ5qX_Wwtto2"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "86PvHSUft0hV"
-      },
       "source": [
         "c -> complex float\n"
-      ]
+      ],
+      "metadata": {
+        "id": "86PvHSUft0hV"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "pjNqllWit2Bd"
-      },
       "source": [
         "m -> timedelta\n"
-      ]
+      ],
+      "metadata": {
+        "id": "pjNqllWit2Bd"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "ZQDWAwnKt3zu"
-      },
       "source": [
         "M -> datetime\n"
-      ]
+      ],
+      "metadata": {
+        "id": "ZQDWAwnKt3zu"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "z0_3x8xZt5j-"
-      },
       "source": [
         "O -> object\n"
-      ]
+      ],
+      "metadata": {
+        "id": "z0_3x8xZt5j-"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "6bID-tcUt7bO"
-      },
       "source": [
         "S -> string\n"
-      ]
+      ],
+      "metadata": {
+        "id": "6bID-tcUt7bO"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "4fTeFRpDt8qG"
-      },
       "source": [
         "U -> unicode string\n"
-      ]
+      ],
+      "metadata": {
+        "id": "4fTeFRpDt8qG"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "b8Ls9-H-t-aX"
-      },
       "source": [
         "V -> fixed chunk of memory for other type ( void )"
-      ]
+      ],
+      "metadata": {
+        "id": "b8Ls9-H-t-aX"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "JyMx-d9buD4b"
-      },
       "source": [
         "### **Checking of Array Datatype**"
-      ]
+      ],
+      "metadata": {
+        "id": "JyMx-d9buD4b"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "1V_B_0SJuJMs"
-      },
       "source": [
         "We can know the datatype of the array using the property dtype."
-      ]
+      ],
+      "metadata": {
+        "id": "1V_B_0SJuJMs"
+      }
     },
     {
       "cell_type": "code",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "MVyokk7EovVc",
-        "outputId": "c242ded9-d28e-4d0a-e2c1-fd6357850ecc"
-      },
+      "execution_count": 71,
       "source": [
-        "arr = np.array(['apple', 'banana', 'cherry'])\n",
-        "\n",
+        "arr = np.array(['apple', 'banana', 'cherry'])\r\n",
+        "\r\n",
         "print(arr.dtype)"
       ],
-      "execution_count": 19,
       "outputs": [
         {
           "output_type": "stream",
@@ -1094,42 +1099,42 @@
             "<U6\n"
           ]
         }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "F5qyAykup4XI"
-      },
-      "source": [
-        "### **Creating Arrays With a Defined Data Type**"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "c3ZnXOfXqDHk"
-      },
-      "source": [
-        "We use the array() function to create arrays, this function can take an optional argument: dtype that allows us to define the expected data type of the array elements."
-      ]
-    },
-    {
-      "cell_type": "code",
+      ],
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "id": "QHyag6Rao10y",
-        "outputId": "514a76ad-0163-4b0a-d298-7be3ac8bd38f"
-      },
+        "id": "MVyokk7EovVc",
+        "outputId": "c242ded9-d28e-4d0a-e2c1-fd6357850ecc"
+      }
+    },
+    {
+      "cell_type": "markdown",
       "source": [
-        "arr = np.array([1, 2, 3, 4], dtype='S')         # Datatype is defined as string\n",
-        "\n",
-        "print(arr)\n",
+        "### **Creating Arrays With a Defined Data Type**"
+      ],
+      "metadata": {
+        "id": "F5qyAykup4XI"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "We use the array() function to create arrays, this function can take an optional argument: dtype that allows us to define the expected data type of the array elements."
+      ],
+      "metadata": {
+        "id": "c3ZnXOfXqDHk"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 72,
+      "source": [
+        "arr = np.array([1, 2, 3, 4], dtype='S')         # Datatype is defined as string\r\n",
+        "\r\n",
+        "print(arr)\r\n",
         "print(arr.dtype)"
       ],
-      "execution_count": 20,
       "outputs": [
         {
           "output_type": "stream",
@@ -1139,33 +1144,33 @@
             "|S1\n"
           ]
         }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "AFv9b_3mqfIY"
-      },
-      "source": [
-        "For i, u, f, S, and U we can define size as well."
-      ]
-    },
-    {
-      "cell_type": "code",
+      ],
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "id": "cvDNC48fqsZP",
-        "outputId": "3c4e1a47-5d3b-4526-a42e-cdc6442b2f19"
-      },
+        "id": "QHyag6Rao10y",
+        "outputId": "514a76ad-0163-4b0a-d298-7be3ac8bd38f"
+      }
+    },
+    {
+      "cell_type": "markdown",
       "source": [
-        "arr = np.array([1, 2, 3, 4], dtype='i4')        # array with data type 4 bytes integer\n",
-        "\n",
-        "print(arr)\n",
+        "For i, u, f, S, and U we can define size as well."
+      ],
+      "metadata": {
+        "id": "AFv9b_3mqfIY"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 73,
+      "source": [
+        "arr = np.array([1, 2, 3, 4], dtype='i4')        # array with data type 4 bytes integer\r\n",
+        "\r\n",
+        "print(arr)\r\n",
         "print(arr.dtype)"
       ],
-      "execution_count": 21,
       "outputs": [
         {
           "output_type": "stream",
@@ -1175,73 +1180,73 @@
             "int32\n"
           ]
         }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "5nhpqj4Xq-G-"
-      },
-      "source": [
-        "### **Converting Data Type on Existing Arrays**"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "TWoO2_YBrloB"
-      },
-      "source": [
-        "By using astype() function we can create a copy of the array, and allows us to specify the data type as a parameter. For example, we can define the datatype integer by writing int or 'i', and for floating point numbers float or 'f'."
-      ]
-    },
-    {
-      "cell_type": "code",
+      ],
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "id": "LOQIoMQPrAS3",
-        "outputId": "4df3ea71-e053-4a04-cf4a-82a1bb7bfe1a"
-      },
+        "id": "cvDNC48fqsZP",
+        "outputId": "3c4e1a47-5d3b-4526-a42e-cdc6442b2f19"
+      }
+    },
+    {
+      "cell_type": "markdown",
       "source": [
-        "arr = np.array([1.1, 2.1, 3.1])      # Array consisting floating point numbers\n",
-        "\n",
-        "newarr = arr.astype(int)             # new array created which is the copy of arr but having integer values of the corresponding elements in arr\n",
-        "\n",
-        "print(newarr)\n",
+        "### **Converting Data Type on Existing Arrays**"
+      ],
+      "metadata": {
+        "id": "5nhpqj4Xq-G-"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "By using astype() function we can create a copy of the array, and allows us to specify the data type as a parameter. For example, we can define the datatype integer by writing int or 'i', and for floating point numbers float or 'f'."
+      ],
+      "metadata": {
+        "id": "TWoO2_YBrloB"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 74,
+      "source": [
+        "arr = np.array([1.1, 2.1, 3.1])      # Array consisting floating point numbers\r\n",
+        "\r\n",
+        "newarr = arr.astype(int)             # new array created which is the copy of arr but having integer values of the corresponding elements in arr\r\n",
+        "\r\n",
+        "print(newarr)\r\n",
         "print(newarr.dtype)"
       ],
-      "execution_count": 22,
       "outputs": [
         {
           "output_type": "stream",
           "name": "stdout",
           "text": [
             "[1 2 3]\n",
-            "int64\n"
+            "int32\n"
           ]
         }
-      ]
-    },
-    {
-      "cell_type": "code",
+      ],
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "id": "FPqFnBkOsnee",
-        "outputId": "67ef97d6-87d5-446d-e665-935c1d9f9cdc"
-      },
+        "id": "LOQIoMQPrAS3",
+        "outputId": "4df3ea71-e053-4a04-cf4a-82a1bb7bfe1a"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 75,
       "source": [
-        "arr = np.array([1, 0, 3, 0, 999])\n",
-        "\n",
-        "newarr = arr.astype(bool)               # we can also convert integer to boolean\n",
-        "\n",
-        "print(newarr)\n",
+        "arr = np.array([1, 0, 3, 0, 999])\r\n",
+        "\r\n",
+        "newarr = arr.astype(bool)               # we can also convert integer to boolean\r\n",
+        "\r\n",
+        "print(newarr)\r\n",
         "print(newarr.dtype)"
       ],
-      "execution_count": 23,
       "outputs": [
         {
           "output_type": "stream",
@@ -1251,195 +1256,343 @@
             "bool\n"
           ]
         }
-      ]
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "FPqFnBkOsnee",
+        "outputId": "67ef97d6-87d5-446d-e665-935c1d9f9cdc"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "C0t81GHatKfc"
-      },
       "source": [
         "\n",
         "\n",
         "---\n",
         "\n"
-      ]
+      ],
+      "metadata": {
+        "id": "C0t81GHatKfc"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "HwpBNsBBtMGv"
-      },
       "source": [
         "### **Comparing Speed of Numpy Arrays and Lists**"
-      ]
+      ],
+      "metadata": {
+        "id": "HwpBNsBBtMGv"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "5w7HrgAYTlIr"
-      },
       "source": [
         "Numpy arrays are 5-100 times faster than python lists."
-      ]
+      ],
+      "metadata": {
+        "id": "5w7HrgAYTlIr"
+      }
     },
     {
       "cell_type": "code",
+      "execution_count": 76,
+      "source": [
+        "import time                               # Importing Time module\r\n",
+        "\r\n",
+        "py_list=[i for i in range(10000000)]      # Python list --> [0,1,2,3,.....,9999999]\r\n",
+        "\r\n",
+        "start=time.time()                         # starting time\r\n",
+        "py_list=[i+100 for i in py_list]          # iterating over python list through a for loop and adding 100 with each element\r\n",
+        "end=time.time()                           # ending time\r\n",
+        "\r\n",
+        "elapsed_time=end-start                    # total time taken to complete the work (for loop iteration)\r\n",
+        "\r\n",
+        "print(round(elapsed_time,6))              # printing the time elapsed upto 6 digit precision"
+      ],
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "0.922223\n"
+          ]
+        }
+      ],
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "seI4YvAfU2MN",
         "outputId": "fb7291e4-cacd-4a76-ea62-b7c0b9234a41"
-      },
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 77,
       "source": [
-        "import time                               # Importing Time module\n",
-        "\n",
-        "py_list=[i for i in range(10000000)]      # Python list --> [0,1,2,3,.....,9999999]\n",
-        "\n",
-        "start=time.time()                         # starting time\n",
-        "py_list=[i+100 for i in py_list]          # iterating over python list through a for loop and adding 100 with each element\n",
-        "end=time.time()                           # ending time\n",
-        "\n",
-        "elapsed_time=end-start                    # total time taken to complete the work (for loop iteration)\n",
-        "\n",
-        "print(round(elapsed_time,6))              # printing the time elapsed upto 6 digit precision"
+        "np_arr=np.array([i for i in range(10000000)])     # numpy array\r\n",
+        "\r\n",
+        "start=time.time()\r\n",
+        "np_arr+=100                                       # adding 100 with each element in rthe array\r\n",
+        "end=time.time()\r\n",
+        "\r\n",
+        "elapsed_time=end-start\r\n",
+        "\r\n",
+        "print(round(elapsed_time,6))"
       ],
-      "execution_count": 24,
       "outputs": [
         {
           "output_type": "stream",
           "name": "stdout",
           "text": [
-            "1.04243\n"
+            "0.006953\n"
           ]
         }
-      ]
-    },
-    {
-      "cell_type": "code",
+      ],
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "k-S9I9mhbRg6",
         "outputId": "c7e52f10-1127-4855-be9f-4b8181a70574"
-      },
-      "source": [
-        "np_arr=np.array([i for i in range(10000000)])     # numpy array\n",
-        "\n",
-        "start=time.time()\n",
-        "np_arr+=100                                       # adding 100 with each element in rthe array\n",
-        "end=time.time()\n",
-        "\n",
-        "elapsed_time=end-start\n",
-        "\n",
-        "print(round(elapsed_time,6))"
-      ],
-      "execution_count": 25,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "0.008377\n"
-          ]
-        }
-      ]
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "csyQQ5-Ndudr"
-      },
       "source": [
         "From the above experiment you can see that numpy array traversal is 116.445 times (0.936337 / 0.008041) faster than python list. "
-      ]
+      ],
+      "metadata": {
+        "id": "csyQQ5-Ndudr"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "_eu8f_bbgkIN"
-      },
       "source": [
         "The reason for Numpy arrays being faster is -"
-      ]
+      ],
+      "metadata": {
+        "id": "_eu8f_bbgkIN"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "xiOcE9mxgsmV"
-      },
       "source": [
         "* Numpy array is a collection of similar data-types that are densely packed in memory. A Python list can have different data-types, which puts lots of extra constraints while doing computation on it.\n",
         "* Numpy is able to divide a task into multiple subtasks and process them parallelly.\n",
         "* Numpy functions are implemented in C. Which again makes it faster compared to Python Lists.\n",
         "\n"
-      ]
+      ],
+      "metadata": {
+        "id": "xiOcE9mxgsmV"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "RfkjL1DdhEYy"
-      },
       "source": [
         "\n",
         "\n",
         "---\n",
         "\n"
-      ]
+      ],
+      "metadata": {
+        "id": "RfkjL1DdhEYy"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "1SJ2nl9dhFWf"
-      },
       "source": [
-        "### **Numpy Basic Operations**"
-      ]
+        "## Comparison of speed between NumPy arrays and Python lists\n",
+        "### NumPy Arrays\n",
+        "NumPy is the fundamental package for scientific computing in Python. NumPy arrays facilitate advanced mathematical and other types of operations on large numbers of data. Typically, such operations are executed more efficiently and with less code than is possible using Python’s built-in sequences. NumPy is not another programming language but a Python extension module. It provides fast and efficient operations on arrays of homogeneous data.\n",
+        "\n",
+        "Some important points about Numpy arrays:\n",
+        "\n",
+        "- We can create a N-dimensional array in python using numpy.array().\n",
+        "- Array are by default Homogeneous, which means data inside an array must be of the same datatype. (Note you can also create a structured array in python).\n",
+        "- Element wise operation is possible.\n",
+        "- Numpy array has the various function, methods, and variables, to ease our task of matrix computation.\n",
+        "- Elements of an array are stored contiguously in memory. For example, all rows of a two dimensioned array must have the same number of columns. Or a three dimensioned array must have the same number of rows and columns on each card. \n",
+        "\n",
+        "[Source: Geeksforgeeks](https://www.geeksforgeeks.org/python-lists-vs-numpy-arrays/)"
+      ],
+      "metadata": {
+        "id": "dF25D5sPxZ-d"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "NRZzKUoyjwXW"
-      },
       "source": [
-        "*   Addition, Subtraction, Multiplication, Division :"
-      ]
+        "### Advantages of using NumPy Arrays Over Python Lists:\n",
+        "\n",
+        "- consumes less memory.\n",
+        "- fast as compared to the python List.\n",
+        "- convenient to use.\n",
+        "\n",
+        "[Source: Geeksforgeeks](https://www.geeksforgeeks.org/python-lists-vs-numpy-arrays/)"
+      ],
+      "metadata": {
+        "id": "hYFfmu8_3QFr"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "86BZlzCO8YLR"
-      },
       "source": [
-        "To add two ndarrays we need to use + operator. Similarly for subtraction, multiplication, division we will use -, *, / operator respectively."
-      ]
+        "### NumPy Arrays are faster than Python Lists because of the following reasons:  \n",
+        "- An array is a collection of homogeneous data-types that are stored in contiguous memory locations. On the other hand, a list in Python is a collection of heterogeneous data types stored in non-contiguous memory locations.\n",
+        "- The NumPy package breaks down a task into multiple fragments and then processes all the fragments parallelly.\n",
+        "- The NumPy package integrates C, C++, and Fortran codes in Python. These programming languages have very little execution time compared to Python.\n",
+        "\n",
+        "[Source: Geeksforgeeks](https://www.geeksforgeeks.org/python-lists-vs-numpy-arrays/)"
+      ],
+      "metadata": {
+        "id": "wTzRiN5_3uGS"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Illustration 1: NumPy Arrays are faster than Python lists\n",
+        "We will calculate the mean of a range of elements (50K to 1 million) in the array using both NumPy and lists. The arrays are randomly generated. A comparison plot between numpy arrays and lists will also be generated. \n",
+        "\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "fPEiA3QF4ly7"
+      }
     },
     {
       "cell_type": "code",
+      "execution_count": 78,
+      "source": [
+        "\"\"\"General comparison between NumPy and lists\"\"\"\r\n",
+        "\r\n",
+        "import numpy as np\r\n",
+        "from time import time\r\n",
+        "import matplotlib.pyplot as plt\r\n",
+        "\r\n",
+        "\r\n",
+        "plot_x = []\r\n",
+        "numpy_plot = []\r\n",
+        "list_plot = []\r\n",
+        "number_of_elements = [x for x in range(50000, 1000000, 50000)]\r\n",
+        "\r\n",
+        "\r\n",
+        "for elements in number_of_elements:\r\n",
+        "\r\n",
+        "  numpy_array = np.random.rand(elements)\r\n",
+        "  list_conv = list(numpy_array)\r\n",
+        "\r\n",
+        "  #Start timing NumPy compuation\r\n",
+        "  start1 = time()\r\n",
+        "\r\n",
+        "  #Compute the mean using NumPy\r\n",
+        "  numpy_mean = np.mean(numpy_array)\r\n",
+        "\r\n",
+        "  #End timing\r\n",
+        "  end1 = time()\r\n",
+        "\r\n",
+        "  #Time taken\r\n",
+        "  time1 = end1 - start1\r\n",
+        "  numpy_plot.append(time1)\r\n",
+        "  print(f\"Computation time(NumPy): {time1}\")\r\n",
+        "\r\n",
+        "  #Start timing list computation\r\n",
+        "  start2 = time()\r\n",
+        "\r\n",
+        "  #Compute the mean using lists\r\n",
+        "  list_mean = np.mean(list_conv)\r\n",
+        "\r\n",
+        "  #End timing\r\n",
+        "  end2 = time()\r\n",
+        "\r\n",
+        "  #Time taken\r\n",
+        "  time2 = end2 - start2\r\n",
+        "  list_plot.append(time2)\r\n",
+        "  print(f\"Computation time(Python list): {time2}\\n\")\r\n",
+        "  print(\".\"*50)\r\n",
+        "\r\n",
+        "\r\n",
+        "x = np.array(number_of_elements)\r\n",
+        "y = np.array(numpy_plot)\r\n",
+        "y1 = np.array(list_plot)\r\n",
+        "plt.plot(x, y, label=\"NumPy Array\")\r\n",
+        "plt.plot(x, y1, label=\"Python lists\")\r\n",
+        "plt.title(\"NumPy array v/s Python list\")\r\n",
+        "plt.xlabel(\"Number of Elements in list/array\")\r\n",
+        "plt.ylabel(\"Computation time in seconds(s)\")\r\n",
+        "plt.grid(color = 'green', linestyle = '--', linewidth = 0.5)\r\n",
+        "plt.legend()\r\n",
+        "plt.show()"
+      ],
+      "outputs": [
+        {
+          "output_type": "error",
+          "ename": "ModuleNotFoundError",
+          "evalue": "No module named 'matplotlib'",
+          "traceback": [
+            "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+            "\u001b[1;31mModuleNotFoundError\u001b[0m                       Traceback (most recent call last)",
+            "\u001b[1;32mC:\\Users\\ABHIRU~1\\AppData\\Local\\Temp/ipykernel_1548/2768436884.py\u001b[0m in \u001b[0;36m<module>\u001b[1;34m\u001b[0m\n\u001b[0;32m      3\u001b[0m \u001b[1;32mimport\u001b[0m \u001b[0mnumpy\u001b[0m \u001b[1;32mas\u001b[0m \u001b[0mnp\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m      4\u001b[0m \u001b[1;32mfrom\u001b[0m \u001b[0mtime\u001b[0m \u001b[1;32mimport\u001b[0m \u001b[0mtime\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m----> 5\u001b[1;33m \u001b[1;32mimport\u001b[0m \u001b[0mmatplotlib\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mpyplot\u001b[0m \u001b[1;32mas\u001b[0m \u001b[0mplt\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m      6\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m      7\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n",
+            "\u001b[1;31mModuleNotFoundError\u001b[0m: No module named 'matplotlib'"
+          ]
+        }
+      ],
       "metadata": {
         "colab": {
-          "base_uri": "https://localhost:8080/"
+          "base_uri": "https://localhost:8080/",
+          "height": 1000
         },
-        "id": "J6L-DqTU5F8x",
-        "outputId": "0797da1f-b886-4577-b186-9720e27cae72"
-      },
+        "id": "t9IOFs1a4lZ1",
+        "outputId": "9de542d9-39a3-4cff-adc0-862ae45256f4"
+      }
+    },
+    {
+      "cell_type": "markdown",
       "source": [
-        "a=np.array([1,2,3])\n",
-        "b=np.array([4,5,6])\n",
-        "\n",
-        "add=a+b     # Addition\n",
-        "sub=a-b     #Subtraction\n",
-        "mul=a*b     #Multiplication\n",
-        "div=a/b     #Division\n",
-        "\n",
-        "print(\"Addition matrix : \",add)\n",
-        "print(\"Subtraction matrix : \",sub)\n",
-        "print(\"Multiplication matrix : \",mul)\n",
+        "## **Numpy Basic Operations**"
+      ],
+      "metadata": {
+        "id": "1SJ2nl9dhFWf"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "*   Addition, Subtraction, Multiplication, Division :"
+      ],
+      "metadata": {
+        "id": "NRZzKUoyjwXW"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "To add two ndarrays we need to use + operator. Similarly for subtraction, multiplication, division we will use -, *, / operator respectively."
+      ],
+      "metadata": {
+        "id": "86BZlzCO8YLR"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "source": [
+        "a=np.array([1,2,3])\r\n",
+        "b=np.array([4,5,6])\r\n",
+        "\r\n",
+        "add=a+b     # Addition\r\n",
+        "sub=a-b     #Subtraction\r\n",
+        "mul=a*b     #Multiplication\r\n",
+        "div=a/b     #Division\r\n",
+        "\r\n",
+        "print(\"Addition matrix : \",add)\r\n",
+        "print(\"Subtraction matrix : \",sub)\r\n",
+        "print(\"Multiplication matrix : \",mul)\r\n",
         "print(\"Division matrix : \",div)"
       ],
-      "execution_count": 26,
       "outputs": [
         {
           "output_type": "stream",
@@ -1451,35 +1604,36 @@
             "Division matrix :  [0.25 0.4  0.5 ]\n"
           ]
         }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "FNcekDg6_CpX"
-      },
-      "source": [
-        "* Sum:\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "wYOw3ejiAjxC"
-      },
-      "source": [
-        "We can get the summation of the array elements using sum() function."
-      ]
-    },
-    {
-      "cell_type": "code",
+      ],
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "id": "JD0OiAxmA0np",
-        "outputId": "8b05d539-9f09-4155-f2da-af9e9a55bdcf"
-      },
+        "id": "J6L-DqTU5F8x",
+        "outputId": "0797da1f-b886-4577-b186-9720e27cae72"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "* Sum:\n"
+      ],
+      "metadata": {
+        "id": "FNcekDg6_CpX"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "We can get the summation of the array elements using sum() function."
+      ],
+      "metadata": {
+        "id": "wYOw3ejiAjxC"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
       "source": [
         "arr=np.array([ 1, 2, 3, 4, 5])\n",
         "\n",
@@ -1487,7 +1641,6 @@
         "\n",
         "print(summ)"
       ],
-      "execution_count": 27,
       "outputs": [
         {
           "output_type": "stream",
@@ -1496,26 +1649,27 @@
             "15\n"
           ]
         }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "KX8obXCZB30U"
-      },
-      "source": [
-        "We can sum over the axis of rows with axis=0 and over columns with axis=1."
-      ]
-    },
-    {
-      "cell_type": "code",
+      ],
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "id": "dDFml1QfCT0m",
-        "outputId": "0941716b-37d0-4d21-ed6b-9fe142c24094"
-      },
+        "id": "JD0OiAxmA0np",
+        "outputId": "8b05d539-9f09-4155-f2da-af9e9a55bdcf"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "We can sum over the axis of rows with axis=0 and over columns with axis=1."
+      ],
+      "metadata": {
+        "id": "KX8obXCZB30U"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
       "source": [
         "arr = np.array([[1,2],[3,4]])\n",
         "\n",
@@ -1528,7 +1682,6 @@
         "# Printing the sum over the axis of columns\n",
         "print(arr.sum(axis=1))"
       ],
-      "execution_count": 28,
       "outputs": [
         {
           "output_type": "stream",
@@ -1540,35 +1693,36 @@
             "[3 7]\n"
           ]
         }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "dkOSi4cEDp-e"
-      },
-      "source": [
-        "* Maximum and Minimum:"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "et3Z2OX-D1k_"
-      },
-      "source": [
-        "For evaluating maximum and minimum we use max() and min() functions."
-      ]
-    },
-    {
-      "cell_type": "code",
+      ],
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "id": "FEkvOwLAE7EM",
-        "outputId": "e2c78e6d-e3d8-4a0c-c7b5-efde0c6fc157"
-      },
+        "id": "dDFml1QfCT0m",
+        "outputId": "0941716b-37d0-4d21-ed6b-9fe142c24094"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "* Maximum and Minimum:"
+      ],
+      "metadata": {
+        "id": "dkOSi4cEDp-e"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "For evaluating maximum and minimum we use max() and min() functions."
+      ],
+      "metadata": {
+        "id": "et3Z2OX-D1k_"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
       "source": [
         "arr = np.array([1,2,654,12,35,0,-302])\n",
         "\n",
@@ -1580,7 +1734,6 @@
         "maximum=arr.max()\n",
         "print(\"Maximum : \",maximum)"
       ],
-      "execution_count": 29,
       "outputs": [
         {
           "output_type": "stream",
@@ -1590,35 +1743,36 @@
             "Maximum :  654\n"
           ]
         }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "DhucwwW0GSYU"
-      },
-      "source": [
-        "* Exponential and Logarithmic operation:"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "kNB_6_CiGeEl"
-      },
-      "source": [
-        "we can use exp() and log() function for exponential and logarithmic operation."
-      ]
-    },
-    {
-      "cell_type": "code",
+      ],
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "id": "gpA2X5hBHPJP",
-        "outputId": "7f4c0b46-14d9-4f7e-dc61-57fe909f823b"
-      },
+        "id": "FEkvOwLAE7EM",
+        "outputId": "e2c78e6d-e3d8-4a0c-c7b5-efde0c6fc157"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "* Exponential and Logarithmic operation:"
+      ],
+      "metadata": {
+        "id": "DhucwwW0GSYU"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "we can use exp() and log() function for exponential and logarithmic operation."
+      ],
+      "metadata": {
+        "id": "kNB_6_CiGeEl"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
       "source": [
         "arr=np.array([1, 2, 3, 4, 5])\n",
         "\n",
@@ -1630,7 +1784,6 @@
         "c=np.log(arr)\n",
         "print(\"Logarithm : \",c)"
       ],
-      "execution_count": 30,
       "outputs": [
         {
           "output_type": "stream",
@@ -1640,64 +1793,65 @@
             "Logarithm :  [0.         0.69314718 1.09861229 1.38629436 1.60943791]\n"
           ]
         }
-      ]
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "gpA2X5hBHPJP",
+        "outputId": "7f4c0b46-14d9-4f7e-dc61-57fe909f823b"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "eMNXLAqOH4a2"
-      },
       "source": [
         "\n",
         "\n",
         "---\n",
         "\n"
-      ]
+      ],
+      "metadata": {
+        "id": "eMNXLAqOH4a2"
+      }
     },
     {
       "cell_type": "markdown",
+      "source": [
+        "## **List Comprehension**"
+      ],
       "metadata": {
         "id": "kXmD4s9gH8SH"
-      },
-      "source": [
-        "### **List Comprehension**"
-      ]
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "xz_QdvlpIEPS"
-      },
       "source": [
         "List comprehensions are used for creating new lists from other iterables like tuples, strings, arrays, lists, etc.\n",
         "\n",
         "Syntax :\n",
         "\n",
         "ListName = [ expression(element) for element in oldList if condition ]"
-      ]
+      ],
+      "metadata": {
+        "id": "xz_QdvlpIEPS"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "luotVATLMlwN"
-      },
       "source": [
         "Advantages:\n",
         "\n",
         "* More time efficient and space efficient than loops.\n",
         "* Require fewer lines of code.\n",
         "* This is faster method."
-      ]
+      ],
+      "metadata": {
+        "id": "luotVATLMlwN"
+      }
     },
     {
       "cell_type": "code",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "eXY_fp5cMhds",
-        "outputId": "c00937e3-dead-4230-f520-6aab21a41384"
-      },
+      "execution_count": null,
       "source": [
         "#List Comprehension of 1D Array\n",
         "List_1=[i for i in range(20)]\n",
@@ -1708,7 +1862,6 @@
         "print(List_2)\n",
         "print(List_3)"
       ],
-      "execution_count": 31,
       "outputs": [
         {
           "output_type": "stream",
@@ -1719,23 +1872,23 @@
             "[15, 35, 60, 26, 37, 18]\n"
           ]
         }
-      ]
-    },
-    {
-      "cell_type": "code",
+      ],
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "id": "yalQaoSxAFZN",
-        "outputId": "5da699f9-e291-49bf-b04c-c964b696bc4d"
-      },
+        "id": "eXY_fp5cMhds",
+        "outputId": "c00937e3-dead-4230-f520-6aab21a41384"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
       "source": [
         "#List Comprehension of 2D Array\n",
         "List_2D=[[i for i in range(4)] for j in range(3)] # 3 by 4 matrix\n",
         "print(List_2D)"
       ],
-      "execution_count": 32,
       "outputs": [
         {
           "output_type": "stream",
@@ -1744,23 +1897,23 @@
             "[[0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3]]\n"
           ]
         }
-      ]
-    },
-    {
-      "cell_type": "code",
+      ],
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "id": "kMqGBfJYA7_n",
-        "outputId": "673999b3-8eea-452f-b816-ed41ff1190cc"
-      },
+        "id": "yalQaoSxAFZN",
+        "outputId": "5da699f9-e291-49bf-b04c-c964b696bc4d"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
       "source": [
         "#List Comprehension of 3D Array\n",
         "List_3D=[[[i for i in range(4)] for j in range(3)] for k in range(2)] # 4X3X2 array\n",
         "print(List_3D)"
       ],
-      "execution_count": 33,
       "outputs": [
         {
           "output_type": "stream",
@@ -1769,52 +1922,56 @@
             "[[[0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3]], [[0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3]]]\n"
           ]
         }
-      ]
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "kMqGBfJYA7_n",
+        "outputId": "673999b3-8eea-452f-b816-ed41ff1190cc"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "YIPfMKohBhDr"
-      },
       "source": [
         "Thus we can create multidimensional array also."
-      ]
+      ],
+      "metadata": {
+        "id": "YIPfMKohBhDr"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "44_VpxUpOjao"
-      },
       "source": [
         "\n",
         "\n",
         "---\n",
         "\n"
-      ]
+      ],
+      "metadata": {
+        "id": "44_VpxUpOjao"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "ao5Too9NOruy"
-      },
       "source": [
         " "
-      ]
+      ],
+      "metadata": {
+        "id": "ao5Too9NOruy"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "4HVw7_6eLOYr"
-      },
       "source": [
         "# NumPy Tutorial : BROADCASTING"
-      ]
+      ],
+      "metadata": {
+        "id": "4HVw7_6eLOYr"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "4I7GAG9rME74"
-      },
       "source": [
         "## Basic Definition and Terminology\n",
         "\n",
@@ -1825,34 +1982,30 @@
         "Now one might be wondering, **why broadcasting?**\n",
         "\n",
         "Well, we've got you covered : \n"
-      ]
+      ],
+      "metadata": {
+        "id": "4I7GAG9rME74"
+      }
     },
     {
       "cell_type": "code",
-      "metadata": {
-        "id": "8ma8aAteNF15"
-      },
+      "execution_count": null,
       "source": [
         "# Imports\n",
         "import numpy as np\n"
       ],
-      "execution_count": 34,
-      "outputs": []
+      "outputs": [],
+      "metadata": {
+        "id": "8ma8aAteNF15"
+      }
     },
     {
       "cell_type": "code",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "W39zQfho9oeh",
-        "outputId": "1c6e1987-9f20-434f-cf08-877b1a1ecb59"
-      },
+      "execution_count": null,
       "source": [
         "a = np.array([1.0, 2.0, 3.0])\n",
         "a"
       ],
-      "execution_count": 35,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -1864,35 +2017,35 @@
           "metadata": {},
           "execution_count": 35
         }
-      ]
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "W39zQfho9oeh",
+        "outputId": "1c6e1987-9f20-434f-cf08-877b1a1ecb59"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "AUZu0h-4NmQy"
-      },
       "source": [
         "Suppose we wanted to update each element to twice its value.\n",
         "\n",
         "Now we know, NumPy operations are usually done on pairs of arrays on an element-by-element basis. \n",
         "In the simplest case, the two arrays must have **exactly the same shape**. So we create another numpy array of the same size and dimensions as `a` and initialize it with all values as `2.0` . This is demonstrated in the snippet below : "
-      ]
+      ],
+      "metadata": {
+        "id": "AUZu0h-4NmQy"
+      }
     },
     {
       "cell_type": "code",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "X2z8p8T0Owh9",
-        "outputId": "0e99fa26-a8db-47f0-a846-fa99f5bd4327"
-      },
+      "execution_count": null,
       "source": [
         "b = np.array([2.0, 2.0, 2.0])\n",
         "# Multiply a and b\n",
         "a*b\n"
       ],
-      "execution_count": 36,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -1904,35 +2057,35 @@
           "metadata": {},
           "execution_count": 36
         }
-      ]
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "X2z8p8T0Owh9",
+        "outputId": "0e99fa26-a8db-47f0-a846-fa99f5bd4327"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "N-168ZSBO5Q9"
-      },
       "source": [
         "While that clearly seems to work as expected, don't you wonder if we could find an alternate way that is a bit more concise, or in **python** terms, *more pythonic?*\n",
         "\n",
         "Well, broadcasting is the way to go!\n",
         "The simplest broadcasting example occurs when an array and a scalar value are combined in an operation :"
-      ]
+      ],
+      "metadata": {
+        "id": "N-168ZSBO5Q9"
+      }
     },
     {
       "cell_type": "code",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "xFVXDB1mQK2w",
-        "outputId": "201c178a-044f-43f7-bed8-b8223b3cca06"
-      },
+      "execution_count": null,
       "source": [
         "c = 2.0\n",
         "# Multiply a and c\n",
         "a*c\n"
       ],
-      "execution_count": 37,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -1944,13 +2097,17 @@
           "metadata": {},
           "execution_count": 37
         }
-      ]
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "xFVXDB1mQK2w",
+        "outputId": "201c178a-044f-43f7-bed8-b8223b3cca06"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "A4hC5SpcSTT1"
-      },
       "source": [
         "There you go. Everything in a single integer variable.\n",
         "\n",
@@ -1963,51 +2120,47 @@
         "\n",
         "As [NumPy docs](https://numpy.org/doc/stable/user/basics.broadcasting.html) puts it : \n",
         "> The stretching analogy is only conceptual. NumPy is smart enough to use the original scalar value without actually making copies so that broadcasting operations are as memory and computationally efficient as possible."
-      ]
+      ],
+      "metadata": {
+        "id": "A4hC5SpcSTT1"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "T5LtYrAZRPQT"
-      },
       "source": [
         "Amazing, and _pythonic_ isn't it? And before we go into the thick of it, here's one more _pythonic_ example : "
-      ]
+      ],
+      "metadata": {
+        "id": "T5LtYrAZRPQT"
+      }
     },
     {
       "cell_type": "code",
-      "metadata": {
-        "id": "tcUYvwSr61CR"
-      },
+      "execution_count": null,
       "source": [
         "# slider that determines magnitude of scalar\n",
         "s = 3 #@param {type:\"slider\", min:0.0, max:10.0, step:1.0}\n"
       ],
-      "execution_count": 38,
-      "outputs": []
+      "outputs": [],
+      "metadata": {
+        "id": "tcUYvwSr61CR"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "Txg1Mkdu8tls"
-      },
       "source": [
         "Change the value of the slider to any integer value between 0 and 10, and following is your go-to array multiplier. Amazing, isn't it?"
-      ]
+      ],
+      "metadata": {
+        "id": "Txg1Mkdu8tls"
+      }
     },
     {
       "cell_type": "code",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "gjA3qkeP8f-S",
-        "outputId": "3f864f93-2136-47e9-deb7-c929ade984ec"
-      },
+      "execution_count": null,
       "source": [
         "a*s"
       ],
-      "execution_count": 39,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -2019,26 +2172,27 @@
           "metadata": {},
           "execution_count": 39
         }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "zN-jnAzKG9T8"
-      },
-      "source": [
-        "And in case no one told you, multiplication wasn't the only arithmetic operation you could do with broadcasting. Let us conisder our primary array `a` and scalar `c`."
-      ]
-    },
-    {
-      "cell_type": "code",
+      ],
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "id": "_f2L9SKuHKbI",
-        "outputId": "19482570-9ecf-47ab-fcaa-0d0b5cf15239"
-      },
+        "id": "gjA3qkeP8f-S",
+        "outputId": "3f864f93-2136-47e9-deb7-c929ade984ec"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "And in case no one told you, multiplication wasn't the only arithmetic operation you could do with broadcasting. Let us conisder our primary array `a` and scalar `c`."
+      ],
+      "metadata": {
+        "id": "zN-jnAzKG9T8"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
       "source": [
         "# Addition\n",
         "print(a+c,\"\\n\")\n",
@@ -2049,7 +2203,6 @@
         "# Subtraction with positions reversed\n",
         "print(c-a)"
       ],
-      "execution_count": 40,
       "outputs": [
         {
           "output_type": "stream",
@@ -2062,47 +2215,51 @@
             "[ 1.  0. -1.]\n"
           ]
         }
-      ]
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "_f2L9SKuHKbI",
+        "outputId": "19482570-9ecf-47ab-fcaa-0d0b5cf15239"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "nBzN-_Ss9X__"
-      },
       "source": [
         "Generally speaking, broadcasting provides an efficient means of vectorizing array operations so that looping occurs in C instead of python. But, as with all other useful things, broadcasting has its own constraints. And that is what we're going to discover in the following sections."
-      ]
+      ],
+      "metadata": {
+        "id": "nBzN-_Ss9X__"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "T7p5cPGZ-VLB"
-      },
       "source": [
         "## Broadcastable Arrays\n",
         "\n",
         "Now if broadcasting were the solution for all vectorization problems, why would we need the entire library of NumPy ;-;\n",
         "\n",
         "So, let's figure out what 'audience' we can use this 'magic trick' on, or in NumPy terms, *which arrays are broadcastable.*  "
-      ]
+      ],
+      "metadata": {
+        "id": "T7p5cPGZ-VLB"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "yBVFJ-Yk-gc9"
-      },
       "source": [
         "In _NumPy_ terms, an array or a set of them is called **broadcastable** to a certain shape if the above rules provide a valid result.\n",
         "_Also, you might like going back to the rules of broadcasting anytime you feel the need to._\n",
         "\n",
         "That being said, let's take a few examples to have a better understanding : "
-      ]
+      ],
+      "metadata": {
+        "id": "yBVFJ-Yk-gc9"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "C9UkEL0wCa6x"
-      },
       "source": [
         "Suppose we have four NumPy arrays, `p`,`q`,`r` and `s` having the following shapes : \n",
         "\n",
@@ -2123,13 +2280,13 @@
         "- `r` acts like a (1,3) array and therefore like a (4,3) array where `r[:]` is broadcast to every row, and finally,\n",
         "\n",
         "- `s` acts like a (4,3) array where the single value is repeated."
-      ]
+      ],
+      "metadata": {
+        "id": "C9UkEL0wCa6x"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "2q375LHEEHb4"
-      },
       "source": [
         "Let's have a glimpse at some examples that may help us understand better.\n",
         "\n",
@@ -2158,17 +2315,14 @@
         "All of the broadcastable arrays above have aptly followed the rules for broadcasting. \n",
         "\n",
         "But just in case there are some avid fans of _the method of reductio ad absurdum_ (in simple words, proof by contradiction, let's see what happens when we try to broadcast arrays against the rules."
-      ]
+      ],
+      "metadata": {
+        "id": "2q375LHEEHb4"
+      }
     },
     {
       "cell_type": "code",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "SjTstjhpFwfB",
-        "outputId": "59a1028f-6f01-427e-aa24-13259e857245"
-      },
+      "execution_count": null,
       "source": [
         "# Array of shape (4,3)\n",
         "against_the_rules_A = np.array([[1, 2, 3], [4, 7, 9], [3, 12, 21], [1, 0, 5]])\n",
@@ -2182,7 +2336,6 @@
         "  print(f'{ve}')\n",
         "  pass"
       ],
-      "execution_count": 41,
       "outputs": [
         {
           "output_type": "stream",
@@ -2191,13 +2344,17 @@
             "operands could not be broadcast together with shapes (4,3) (2,1) \n"
           ]
         }
-      ]
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "SjTstjhpFwfB",
+        "outputId": "59a1028f-6f01-427e-aa24-13259e857245"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "iUWVDGuUIhei"
-      },
       "source": [
         "Just as we said, NumPy returns `ValueError` when trying to broadcast arrays that aren't broadcastable.\n",
         "\n",
@@ -2215,26 +2372,23 @@
         "```\n",
         "\n",
         "So, the \"NOT-VALID\" part being dealt with, let's see where we CAN use broadcasting.\n"
-      ]
+      ],
+      "metadata": {
+        "id": "iUWVDGuUIhei"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "Ieo9WupBKzcY"
-      },
       "source": [
         "1. Adding arrays of different dimension counts\n"
-      ]
+      ],
+      "metadata": {
+        "id": "Ieo9WupBKzcY"
+      }
     },
     {
       "cell_type": "code",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "ApKmlRLgLW32",
-        "outputId": "a7647fde-398f-4ffa-f39e-19244a5a816f"
-      },
+      "execution_count": null,
       "source": [
         "# 2D \n",
         "A_2D = np.array([[ 0.0,  5.0,  0.0],\n",
@@ -2247,7 +2401,6 @@
         "\n",
         "A_2D + A_1D"
       ],
-      "execution_count": 42,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -2262,13 +2415,17 @@
           "metadata": {},
           "execution_count": 42
         }
-      ]
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "ApKmlRLgLW32",
+        "outputId": "a7647fde-398f-4ffa-f39e-19244a5a816f"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "urovtn3GL9Kl"
-      },
       "source": [
         "As shown in the figure alongside, A_1D is added to each row of A_2D. \n",
         "\n",
@@ -2277,17 +2434,14 @@
         "Quite fascinating, yet unsurprising by NumPy standards, isn't it?\n",
         "\n",
         "Let's look at another one."
-      ]
+      ],
+      "metadata": {
+        "id": "urovtn3GL9Kl"
+      }
     },
     {
       "cell_type": "code",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "Q9aKH1e3Lb3W",
-        "outputId": "93ccabd9-73ef-4c48-c7b9-64f1ae994218"
-      },
+      "execution_count": null,
       "source": [
         "p = np.array([5.0, 10.0, 25.0, 60.0])\n",
         "q = np.array([3.0, 9.0, 6.0])\n",
@@ -2295,7 +2449,6 @@
         "# Magic Code\n",
         "p[:, np.newaxis] + q"
       ],
-      "execution_count": 43,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -2310,13 +2463,17 @@
           "metadata": {},
           "execution_count": 43
         }
-      ]
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "Q9aKH1e3Lb3W",
+        "outputId": "93ccabd9-73ef-4c48-c7b9-64f1ae994218"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "BJcPuYNlMwUW"
-      },
       "source": [
         "Now you must be wondering, _what happened there?_\n",
         "\n",
@@ -2328,16 +2485,19 @@
         "\n",
         "In the example above, it makes the 1D array `p` a 2-dimensional one, with dimensions `4x1`. \n",
         "Combining the `4x1` array with `q`, which has shape `(3,)`, yields a `4x3` array."
-      ]
+      ],
+      "metadata": {
+        "id": "BJcPuYNlMwUW"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "kMD9rYoxPATV"
-      },
       "source": [
         "With that we conclude our discussion on broadcastable arrays. Armed with this basic knowledge of rules and syntax, let's explore some practical examples."
-      ]
+      ],
+      "metadata": {
+        "id": "kMD9rYoxPATV"
+      }
     }
   ]
 }


### PR DESCRIPTION
Added:
-Advantages of using NumPy Arrays Over Python Lists
-NumPy Arrays are faster than Python Lists because of the following reasons
-Illustration 1
-Illustration 2
-Illustration 3
-Bottom line

Check for RunTime errors and "execution count" in Github code.
